### PR TITLE
Updated the script to fix the issue.

### DIFF
--- a/Backend/transformModule.py
+++ b/Backend/transformModule.py
@@ -16,8 +16,8 @@ class TransformationModule(BaseModule):
                 raise ValueError("Join operation requires exactly two input DataFrames.")
             
             input0 = inputs[0].alias("t1")
-            random_alias = f"t2_{uuid.uuid4().hex[:8]}"  # Generate a unique alias for the second DataFrame
-            input1 = inputs[1].alias(random_alias)
+            random_suffix = node.params["Suffix"]  # Generate a unique alias for the second DataFrame
+            input1 = inputs[1].alias(random_suffix)
 
             # Validate that Input0 and Input1 columns exist in the respective DataFrames
             if node.params['Input0'] not in inputs[0].columns:
@@ -34,7 +34,7 @@ class TransformationModule(BaseModule):
             # Handle duplicate columns by renaming or excluding them
             columns_from_t1 = [f"t1.{col} as {col}" for col in inputs[0].columns]
             columns_from_t2 = [
-                f"{random_alias}.{col} as {col}_{random_alias}" 
+                f"{random_suffix}.{col} as {col}_{random_suffix}" 
                 for col in inputs[1].columns if col != node.params['Input1']
             ]
             node.output = joined_df.selectExpr(*columns_from_t1, *columns_from_t2)

--- a/main.py.py
+++ b/main.py.py
@@ -42,13 +42,16 @@ if __name__ == "__main__":
         {"id": "CSV_SOURCE", "function": "read_csv", "params": {"path": "dbfs:/FileStore/tables/Product.csv"}},
         {"id": "PARQUET_SOURCE", "function": "read_parquet", "params": {"path": "dbfs:/FileStore/tables/SalesOrderDetail_1.parquet"}},
         {"id": "SQL_SOURCE", "function": "read_sql", "params": {"host": "psslp-genai.database.windows.net","port":"1433","user":"sqladmin","password":"sql@1234","database":"AdventureWorks2022","table":"Sales.ShoppingCartItem"}},
-        {"id": "SELECTED_COLUMNS", "function": "select_dataframe", "params": {"columns": ["ProductID","LineTotal"]}, "inputs": ["PARQUET_SOURCE"]}
-
+        
+        
+        # SELECT DATAFRAME
+        {"id": "SELECTED_COLUMNS", "function": "select_dataframe", "params": {"columns": ["ProductID","LineTotal"]}, "inputs": ["PARQUET_SOURCE"]},
+        
         
     #     # JOIN TABLE TEST
-    #     {"id": "Join_Sales_Order_With_Product", "function": "join", "params": {"Input0": "ProductID","Input1":"ProductID", "joinType":"right"}, "inputs": ["CSV_SOURCE", "PARQUET_SOURCE"]},
+        {"id": "Join_Sales_Order_With_Product", "function": "join", "params": {"Input0": "ProductID","Input1":"ProductID", "joinType":"right","Suffix":"TestSuffix"}, "inputs": ["CSV_SOURCE", "PARQUET_SOURCE"]},
         
-    #     {"id": "Join_Product_With_Other", "function": "join", "params": {"Input0": "ProductID","Input1":"ProductID", "joinType":"left"}, "inputs": ["Join_Sales_Order_With_Product", "SQL_SOURCE"]},
+        {"id": "Join_Product_With_Other", "function": "join", "params": {"Input0": "ProductID","Input1":"ProductID", "joinType":"left","Suffix":"secondTestSuffix"}, "inputs": ["Join_Sales_Order_With_Product", "SQL_SOURCE"]},
         
     #     {"id": "Join_Product_With_Other_test", "function": "join", "params": {"Input0": "ProductID","Input1":"ProductID", "joinType":"inner"}, "inputs": ["Join_Sales_Order_With_Product", "Join_Product_With_Other"]},
         


### PR DESCRIPTION
A suffix parameter is used in the configuration and when columns name are same while joining it will automatically add the suffix.

This is the corresponding parameter
{"id": "Join_Sales_Order_With_Product", "function": "join", "params": {"Input0": "ProductID","Input1":"ProductID", "joinType":"right","Suffix":"TestSuffix"}, "inputs": ["CSV_SOURCE", "PARQUET_SOURCE"]},